### PR TITLE
Add ability to use with kubernetes configmaps

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -47,23 +47,23 @@ mv ${PROTOS_PATH}/google/api/annotations.proto ${DESTINATION_PATH}
 mv ${PROTOS_PATH}/google/api/http.proto ${DESTINATION_PATH}
 
 echo "GENERATING... stubs go"
-find ${PROTOS_PATH} -type f -name "*.proto" -exec protoc -I${PROTOS_PATH} \
+find -L ${PROTOS_PATH} -not -path '*/\.*' -type f -name "*.proto" -exec protoc -I${PROTOS_PATH} \
   --proto_path=${PROTOS_PATH} \
   -I${GOPATH}/src \
   -I${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
   --go_out=plugins=grpc:${STUBS_PATH} \
-	{} \;
+  {} \;
 
 echo "GENERATING... reverse-proxy"
-find ${PROTOS_PATH} -type f -name "*.proto" -exec protoc -I${PROTOS_PATH} \
+find -L ${PROTOS_PATH} -not -path '*/\.*' -type f -name "*.proto" -exec protoc -I${PROTOS_PATH} \
   --proto_path=${PROTOS_PATH} \
   -I${GOPATH}/src \
   -I${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
   --grpc-gateway_out=logtostderr=true:${STUBS_PATH} \
-	{} \;
+  {} \;
 
 echo "GENERATING... swagger definitions"
-find ${PROTOS_PATH} -type f -name "*.proto" -exec protoc -I${PROTOS_PATH} \
+find -L ${PROTOS_PATH} -not -path '*/\.*' -type f -name "*.proto" -exec protoc -I${PROTOS_PATH} \
   --proto_path=${PROTOS_PATH} \
   -I${GOPATH}/src \
   -I${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \


### PR DESCRIPTION
Kubernetes configmaps place files in hidden folders and use symlinks to these files. Using a traditional `find` command will return the absolute path to the file (which is an undesired path), instead of the symlink (desired path). This pr will update the  `*.proto` file find command to return all files AND SYMLINKS that are not in a hidden folder.

Ex:
```
$ ls -al protos
  drwxr-xr-x    1 root     root          4096 Aug  8 21:35 .
  drwxr-xr-x    1 root     root          4096 Aug  8 19:17 ..
  -rw-r--r--    1 root     root          3708 Aug  8 19:18 protos/my.proto
$ kubectl create configmap my-protos --from-file=protos/
$ kubectl create -f deploy.yaml
$ kubectl exec -it container /bin/bash
# ls -al /opt/generator/protos
  drwxrwxrwx    3 root     root          4096 Aug  8 19:46 .
  drwxr-xr-x    3 root     root          4096 Aug  8 20:02 ..
  drwxr-xr-x    2 root     root          4096 Aug  8 19:46 ..2018_08_08_19_46_03.335203197
  lrwxrwxrwx    1 root     root            31 Aug  8 19:46 ..data -> ..2018_08_08_19_46_03.335203197
  lrwxrwxrwx    1 root     root            20 Aug  8 19:46 my.proto -> ..data/my.proto
```